### PR TITLE
Update radial.c

### DIFF
--- a/faclib/radial.c
+++ b/faclib/radial.c
@@ -1506,7 +1506,7 @@ static double ConfigEnergyVarianceParts0(SHELL *bra, int ia, int ib,
 	e += b;
       }
     }
-    if (IsOdd((ja+jb)/2+1)) e = -e;
+    if (IsOdd((ja+jb+m2)/2)) e = -e;
     break;
   case 2:
     k0 = 4;
@@ -1518,7 +1518,9 @@ static double ConfigEnergyVarianceParts0(SHELL *bra, int ia, int ib,
       for (kp = kp0; kp <= kp1; kp += 2) {
 	b = W6j(k, kp, m2, jb, ja, ja);
 	b = -b*b;
-	b += W6j(jb, jb, k, ja, ja, m2)*W6j(jb, jb, k, ja, ja, kp);
+	d=W6j(jb, jb, k, ja, ja, m2)*W6j(jb, jb, k, ja, ja, kp);
+	if(IsOdd((m2+kp)/2)) b -= d;
+	else b += d;
 	if (m2 == kp) {
 	  b -= (1.0/(m2+1.0)-1.0/(jb+1.0))*a;
 	} else {
@@ -1580,14 +1582,16 @@ static double ConfigEnergyVarianceParts0(SHELL *bra, int ia, int ib,
     kp1 = ja+jb;
     for (k = k0; k <= k1; k += 4) {
       for (kp = kp0; kp <= kp1; kp += 2) {
-	b = -W6j(jb, jb, k, ja, ja, kp)/(jb+1.0);
+      	b=W6j(jb, jb, k, ja, ja, kp)/(jb+1.0);
+      	if(IsOdd(kp/2)) b=-b;
 	c = W6j(k, kp, m2, ja, jb, jb)*W6j(k, kp, m2, jb, ja, ja);
-	if (IsOdd((ja+jb)/2)) b += c;
+	if (IsOdd((ja+jb+kp+m2)/2)) b += c;
 	else b -= c;
 	c = -1.0/(jb+1.0);
 	if (kp == m2) c += 1.0/(m2+1.0);
-	c *= W6j(ja, jb, m2, jb, ja, k);
-	b += c/ja;
+	c *= W6j(ja, jb, m2, jb, ja, k)/ja;
+	if(IsOdd(m2/2)) b += c;
+	else b -= c;
 	b /= 0.5*ja;
 	b *= FKB(ka, kb, k)*GKB(ka, kb, kp);
 	e += b;
@@ -1675,7 +1679,7 @@ static double ConfigEnergyVarianceParts1(SHELL *bra, int i,
       if (fabs(b) < EPS30) continue;
       b *= 2.0/((k+1.0)*(js+1.0));
       b *= FKB(ks, ka, k)*FKB(ks, kb, k);
-      if (IsOdd((ja+jb)/2)) b = -b;
+      if (IsEven((ja+jb+m2)/2)) b = -b;
       e += b;
     }
     break;
@@ -1709,7 +1713,7 @@ static double ConfigEnergyVarianceParts1(SHELL *bra, int i,
 	b *= W6j(jb, jb, k, js, js, kp);
 	if (fabs(b) < EPS30) continue;
 	b /= (js+1.0);
-	if (IsOdd((ja+jb+kp)/2)) b = -b;
+	if (IsEven((ja+jb+kp+m2)/2)) b = -b;
 	b *= 2.0*FKB(ks, ka, k)*GKB(ks, kb, kp);
 	e += b;
       }
@@ -1868,9 +1872,12 @@ double ConfigEnergyShift(int ns, SHELL *bra, int ia, int ib, int m2) {
       for (k = kmin; k <= kmax; k += 4) {
 	b = W6j(k, ja, ja, m2, jb, jb);	
 	if (fabs(b) > EPS30) {
-	  a -= b*FKB(k0, k1, k);
+	  a += b*FKB(k0, k1, k);
 	}
       }
+      
+      if(IsOdd(m2/2)) a=-a;
+      
       kmin = abs(ja-jb);
       kmax = ja + jb;
       c = 1.0/((ja+1.0)*(jb+1.0));


### PR DESCRIPTION
The formulas for the UTA width and shift for the case of electric and magnetic multipoles are taken from Bar-Shalom et al. 1995. These expressions are wrong for magnetic transitions and for electric transitions of even multipole order. The corrected formulas were implemented (M. Krief & A. Feigel, work in progress).

The various two-electron variance formulas are implemented in:
ConfigEnergyVarianceParts0
p=0 is Q1
p=1 is Q2
p=2 is Q3
p=3 is Q4
p=4 is Q5
p=5 is Q6
p=6 is P1
p=7 is P2
p=8 is P3
p=9 is P4

ConfigEnergyVarianceParts1 
p=0 is P5 
p=1 is P6
p=2 is P7.

The corrections to the formulas are:
For P5,P7,Q2 and the energy shift, the phase (-1)^(ja+jb+1) was replaced by  (-1)^(ja+jb+m2).
For Q3 the phase (-1)^(k'+m2) multiply the two 6js term.
For Q6 the phase (-1)^(ja+jb) was replaced by (-1)^(ja+jb+m2+k') and also two new phases (-1)^k' and (-1)^m2 appear.

For the energy shift,
in the function ConfigEnergyShift
a phase (-1)^m2 was added to the FKT sum.

